### PR TITLE
add concourse.pages group

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -58,6 +58,7 @@ instance_groups:
         scim:
           groups:
             concourse.admin: 'Group that allows access to Concourse "main" team'
+            concourse.pages: 'Members of the Concourse "pages" team'
           users:
           - name: credhub_admin_user_staging
             password: ((/toolingbosh/credhub-staging/credhub-admin-user-password))


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds the concourse.pages group to uaa

## security considerations

Members of this group will have the "member" role in the "pages" team in concourse.