### PR TITLE
add concourse.pages as a valid scope for concourse clients

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -85,13 +85,13 @@ instance_groups:
           concourse_staging:
             <<: *client-template
             scope: openid,concourse.admin
-            authorities: uaa.none,concourse.admin
+            authorities: uaa.none,concourse.admin,concourse.pages
             redirect-uri: https://ci.fr-stage.cloud.gov/sky/issuer/callback
             secret: ((concourse_client_secret_staging))
           concourse_production:
             <<: *client-template
             scope: openid,concourse.admin
-            authorities: uaa.none,concourse.admin
+            authorities: uaa.none,concourse.admin,concourse.pages
             redirect-uri: https://ci.fr.cloud.gov/sky/issuer/callback
             secret: ((concourse_client_secret_production))
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds the concourse.pages as a valid scope for the concourse staging and prod clients

## security considerations

This is necessary for concourse.pages scope to be passed back to concourse.
