### PR TITLE
add concourse.pages to scope and authorities

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -84,13 +84,13 @@ instance_groups:
           # Concourse auth
           concourse_staging:
             <<: *client-template
-            scope: openid,concourse.admin
+            scope: openid,concourse.admin,concourse.pages
             authorities: uaa.none,concourse.admin,concourse.pages
             redirect-uri: https://ci.fr-stage.cloud.gov/sky/issuer/callback
             secret: ((concourse_client_secret_staging))
           concourse_production:
             <<: *client-template
-            scope: openid,concourse.admin
+            scope: openid,concourse.admin,concourse.pages
             authorities: uaa.none,concourse.admin,concourse.pages
             redirect-uri: https://ci.fr.cloud.gov/sky/issuer/callback
             secret: ((concourse_client_secret_production))


### PR DESCRIPTION
## Changes proposed in this pull request:

Group name needs to be in scope and authorities

## security considerations

Enables concourse to see the concourse.pages scope.
