### PR TITLE
add credhub permissions to concourse-staging

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -77,8 +77,8 @@ instance_groups:
           # Concourse auth
           concourse_staging:
             <<: *client-template
-            scope: openid,concourse.admin
-            authorities: uaa.none,concourse.admin
+            scope: openid,concourse.admin,credhub.read,credhub.write
+            authorities: uaa.none,concourse.admin,credhub.read,credhub.write
             redirect-uri: https://ci.fr-stage.cloud.gov/sky/issuer/callback
             secret: ((concourse_client_secret_staging))
           concourse_production:


### PR DESCRIPTION
## Changes proposed in this pull request:
- add credhub permissions to concourse-staging

## security considerations
Adds access to credhub for concourse. This means one more place can access it, but ultimately drives towards security by enabling better secrets management