### PR TITLE
doomsday needs write too?

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -134,7 +134,7 @@ instance_groups:
           doomsday_readonly_staging:
             override: true
             authorized-grant-types: client_credentials,refresh_token
-            authorities: credhub.read
+            authorities: credhub.read, credhub.write
             scope: uaa.none,credhub.read
             secret: ((doomsday_readonly_secret_staging))
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- doomsday client needs credhub.write
-
-

## security considerations
None