### PR TITLE
drop common file so credhub will manage all the secrets for opsuaa-west

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -175,8 +175,6 @@ jobs:
   - in_parallel:
     - get: uaa-config
       trigger: true
-    - get: common
-      trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-west
     - get: stemcell-bionic
@@ -197,7 +195,6 @@ jobs:
       - uaa-customized-release/*.tgz
       - secureproxy-release/*.tgz
       vars_files:
-      - common/opsuaa.yml
       - terraform-yaml/state.yml
       ops_files:
       - uaa-config/ops/add-bpm.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- drop common file so credhub will manage all the secrets for opsuaa-west


## security considerations
credhub is probably a safer place to keep secrets
