### PR TITLE
adding concourse config for support viewer role

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -315,6 +315,7 @@ instance_groups:
           groups:
             concourse.admin: 'Group that allows access to Concourse "main" team'
             concourse.pages: 'Members of the Concourse "pages" team'
+            concourse.viewer: 'Support members holding viewers role'
           users:
           - name: credhub_admin_user_staging
             password: ((/toolingbosh/credhub-staging/credhub-admin-user-password))
@@ -340,14 +341,14 @@ instance_groups:
           # Concourse auth
           concourse_staging:
             <<: *client-template
-            scope: openid,concourse.admin,concourse.pages,credhub.read,credhub.write
-            authorities: uaa.none,concourse.admin,concourse.pages,credhub.read,credhub.write
+            scope: openid,concourse.admin,concourse.pages,concourse.viewer,credhub.read,credhub.write
+            authorities: uaa.none,concourse.admin,concourse.pages,concourse.viewer,credhub.read,credhub.write
             redirect-uri: https://ci.fr-stage.cloud.gov/sky/issuer/callback
             secret: ((concourse_client_secret_staging))
           concourse_production:
             <<: *client-template
-            scope: openid,concourse.admin,concourse.pages
-            authorities: uaa.none,concourse.admin,concourse.pages
+            scope: openid,concourse.admin,concourse.pages,concourse.viewer
+            authorities: uaa.none,concourse.admin,concourse.pages,concourse.viewer
             redirect-uri: https://ci.fr.cloud.gov/sky/issuer/callback
             secret: ((concourse_client_secret_production))
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Setting up Concourse to support read-only mode for support and contract work

## security considerations
Viewer role allows read only access to Concourse - Support members can not make changes nor launch new jobs
