### PR TITLE
update resource types to use hardened images

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,8 +1,21 @@
 resource_types:
-- name: s3-iam
-  type: docker-image
+- name: registry-image
+  type: registry-image
   source:
-    repository: 18fgsa/s3-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
+- name: s3-iam
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: s3-resource
+    aws_region: us-gov-west-1
+    tag: latest
 
 - name: bosh-deployment
   type: docker-image
@@ -10,9 +23,13 @@ resource_types:
     repository: cloudfoundry/bosh-deployment-resource
 
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: slack-notification-resource
+    aws_region: us-gov-west-1
+    tag: latest
 
 resources:
 - name: uaa-config


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updates pipeline to use our current hardened images

## security considerations
Removes slack-notification-resource and replaces with hardened image